### PR TITLE
Integrate mindoc to the MIND Tools package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,21 @@
 
 	<modules>
 		<module>mind-compiler</module>
+		<module>mindoc</module>
 	</modules>
 
 	<dependencies>
 		<dependency>
 			<groupId>${modules.common.groupId}</groupId>
 			<artifactId>mindc</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>mindoc</artifactId>
 			<version>${modules.common.version}</version>
 			<classifier>bin</classifier>
 			<type>zip</type>
@@ -138,7 +147,6 @@
 						</goals>
 					</execution>
 
-<!-- TODO: Restore once "mindoc" is re-integrated in the release as a module and dependency
 					<execution>
 						<id>test-makefile-assembly-doc</id>
 						<phase>integration-test</phase>
@@ -156,7 +164,6 @@
 							<goal>exec</goal>
 						</goals>
 					</execution>
--->
 				</executions>
 			</plugin>
 

--- a/src/assemble/bin-integration-repo.xml
+++ b/src/assemble/bin-integration-repo.xml
@@ -15,6 +15,11 @@
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
+
+		<fileSet>
+			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
 	</fileSets>
 
 	<files>

--- a/src/assemble/bin-integration.xml
+++ b/src/assemble/bin-integration.xml
@@ -15,6 +15,11 @@
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
+
+		<fileSet>
+			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
 	</fileSets>
 
 	<files>

--- a/src/assemble/bin-release-repo.xml
+++ b/src/assemble/bin-release-repo.xml
@@ -18,6 +18,11 @@
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
+
+		<fileSet>
+			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
 	</fileSets>
 
 	<files>

--- a/src/assemble/bin-release.xml
+++ b/src/assemble/bin-release.xml
@@ -18,6 +18,11 @@
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
+
+		<fileSet>
+			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
 	</fileSets>
 
 	<files>

--- a/src/docbkx/Mindc-and-plugins-User-guide.xml
+++ b/src/docbkx/Mindc-and-plugins-User-guide.xml
@@ -104,6 +104,16 @@
                 hereafter.</para>
         </section>
     </chapter>
+    <chapter>
+        <title>MIND tools</title>
+        <section>
+            <title>Mindoc tool</title>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="../../mindoc/src/docbkx/sections/mindoc_aim.xml"/>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="../../mindoc/src/docbkx/sections/mindoc_cmd.xml"/>
+        </section>
+    </chapter>
     <appendix>
         <title>Annex</title>
         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"


### PR DESCRIPTION
# Integrate mindoc to the MIND Tools package
## Note

This Pull Request works in conjunction with the according manifest upgrade:
https://github.com/MIND-Tools/mind-tools-release-manifest/pull/2
## Contribution
- Maven sub-module
- Maven dependency for easy unpackaging of the constructed package and docbookx resources
- Integration test restored (build the examples/doc example, including the "check_doc" Makefile target with Linklint) - Note: Perl is needed for this task (as in legacy mindoc)
- Mindoc documentation section integrated in the User Guide chapters
