### PR TITLE
Integrate all the Mind4SE plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,23 @@
 	<modules>
 		<module>mind-compiler</module>
 		<module>mindoc</module>
+		<module>Optimization-Backend</module>
+		<module>global-extensions</module>
+		<module>dumpdot-annotation</module>
+		<module>mindot-viewer</module>
+		<module>mindunit/mindunit-runtime</module>
+		<module>mindunit/mindunit</module>
+		<module>iar-extension</module>
+		<module>diab-extension</module>
+		<module>garbage-composite-annotation</module>
+		<module>mind-cpp</module>
+		<module>generic-compiler-extension</module>
+		<module>generic-compiler-executor</module>
+		<module>dependency-tools</module>
+		<module>examples</module>
+		<module>mind-visual-diff</module>
+		<module>simple-c-macro-generator</module>
+		<module>json-dump</module>
 	</modules>
 
 	<dependencies>
@@ -58,6 +75,129 @@
 			<version>${modules.common.version}</version>
 			<classifier>bin</classifier>
 			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>global-extensions</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>dumpdot-annotation</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>mindot-viewer</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>mindunit</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>iar-extension</artifactId>
+			<version>${modules.common.version}</version>
+			<type>jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>diab-extension</artifactId>
+			<version>${modules.common.version}</version>
+			<type>jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>garbage-composite-annotation</artifactId>
+			<version>${modules.common.version}</version>
+			<type>jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>mindcpp</artifactId>
+			<version>${modules.cpp.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>mindc-optimizations</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>generic-compiler-executor</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>dependency-tools</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>generic-compiler-extension</artifactId>
+			<version>${modules.common.version}</version>
+			<type>jar</type>
+		</dependency>
+		
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>examples</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+		
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>mind-visual-diff</artifactId>
+			<version>${module.diff.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>simple-c-macro-generator</artifactId>
+			<version>${modules.common.version}</version>
+			<classifier>bin</classifier>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>${modules.common.groupId}</groupId>
+			<artifactId>json-dump</artifactId>
+			<version>${module.json.version}</version>
+			<type>jar</type>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,9 @@
 	<properties>
 		<modules.common.groupId>org.ow2.mind</modules.common.groupId>
 		<modules.common.version>2.2-SNAPSHOT</modules.common.version>
+		<modules.cpp.version>0.1.1-SNAPSHOT</modules.cpp.version>
+		<module.diff.version>0.1.1-SNAPSHOT</module.diff.version>
+		<module.json.version>0.1.0-SNAPSHOT</module.json.version>
 
 		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 		<release.buildNumber>${maven.build.timestamp}</release.buildNumber>

--- a/src/assemble/bin-integration-repo.xml
+++ b/src/assemble/bin-integration-repo.xml
@@ -10,6 +10,21 @@
 	</formats>
 	<includeBaseDirectory>true</includeBaseDirectory>
 
+	<dependencySets>
+		<dependencySet>
+			<useTransitiveDependencies>false</useTransitiveDependencies>
+			<outputDirectory>ext</outputDirectory>
+			<includes>
+				<include>${modules.common.groupId}:iar-extension</include>
+				<include>${modules.common.groupId}:diab-extension</include>
+				<include>${modules.common.groupId}:garbage-composite-annotation</include>
+				<include>${modules.common.groupId}:generic-compiler-extension</include>
+				<include>${modules.common.groupId}:json-dump</include>
+			</includes>
+			<fileMode>0644</fileMode>
+		</dependencySet>
+	</dependencySets>
+
 	<fileSets>
 		<fileSet>
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
@@ -18,6 +33,50 @@
 
 		<fileSet>
 			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindunit-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindcpp-${modules.cpp.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/global-extensions-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/generic-compiler-executor-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindot-viewer-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dependency-tools-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dumpdot-annotation-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindc-optimizations-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/examples-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mind-visual-diff-${module.diff.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/simple-c-macro-generator-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
 	</fileSets>

--- a/src/assemble/bin-integration.xml
+++ b/src/assemble/bin-integration.xml
@@ -10,6 +10,21 @@
 	</formats>
 	<includeBaseDirectory>true</includeBaseDirectory>
 
+	<dependencySets>
+		<dependencySet>
+			<useTransitiveDependencies>false</useTransitiveDependencies>
+			<outputDirectory>ext</outputDirectory>
+			<includes>
+				<include>${modules.common.groupId}:iar-extension</include>
+				<include>${modules.common.groupId}:diab-extension</include>
+				<include>${modules.common.groupId}:garbage-composite-annotation</include>
+				<include>${modules.common.groupId}:generic-compiler-extension</include>
+				<include>${modules.common.groupId}:json-dump</include>
+			</includes>
+			<fileMode>0644</fileMode>
+		</dependencySet>
+	</dependencySets>
+
 	<fileSets>
 		<fileSet>
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
@@ -18,6 +33,50 @@
 
 		<fileSet>
 			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindunit-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindcpp-${modules.cpp.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/global-extensions-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/generic-compiler-executor-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindot-viewer-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dependency-tools-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dumpdot-annotation-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindc-optimizations-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/examples-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mind-visual-diff-${module.diff.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/simple-c-macro-generator-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
 	</fileSets>

--- a/src/assemble/bin-release-repo.xml
+++ b/src/assemble/bin-release-repo.xml
@@ -13,6 +13,21 @@
 	</formats>
 	<includeBaseDirectory>true</includeBaseDirectory>
 
+	<dependencySets>
+		<dependencySet>
+			<useTransitiveDependencies>false</useTransitiveDependencies>
+			<outputDirectory>ext</outputDirectory>
+			<includes>
+				<include>${modules.common.groupId}:iar-extension</include>
+				<include>${modules.common.groupId}:diab-extension</include>
+				<include>${modules.common.groupId}:garbage-composite-annotation</include>
+				<include>${modules.common.groupId}:generic-compiler-extension</include>
+				<include>${modules.common.groupId}:json-dump</include>
+			</includes>
+			<fileMode>0644</fileMode>
+		</dependencySet>
+	</dependencySets>
+
 	<fileSets>
 		<fileSet>
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
@@ -21,6 +36,50 @@
 
 		<fileSet>
 			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindunit-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindcpp-${modules.cpp.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/global-extensions-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/generic-compiler-executor-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindot-viewer-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dependency-tools-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dumpdot-annotation-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindc-optimizations-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/examples-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mind-visual-diff-${module.diff.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/simple-c-macro-generator-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
 	</fileSets>

--- a/src/assemble/bin-release.xml
+++ b/src/assemble/bin-release.xml
@@ -13,6 +13,21 @@
 	</formats>
 	<includeBaseDirectory>true</includeBaseDirectory>
 
+	<dependencySets>
+		<dependencySet>
+			<useTransitiveDependencies>false</useTransitiveDependencies>
+			<outputDirectory>ext</outputDirectory>
+			<includes>
+				<include>${modules.common.groupId}:iar-extension</include>
+				<include>${modules.common.groupId}:diab-extension</include>
+				<include>${modules.common.groupId}:garbage-composite-annotation</include>
+				<include>${modules.common.groupId}:generic-compiler-extension</include>
+				<include>${modules.common.groupId}:json-dump</include>
+			</includes>
+			<fileMode>0644</fileMode>
+		</dependencySet>
+	</dependencySets>
+
 	<fileSets>
 		<fileSet>
 			<directory>target/dependency/mindc-${modules.common.version}</directory>
@@ -21,6 +36,50 @@
 
 		<fileSet>
 			<directory>target/dependency/mindoc-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindunit-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindcpp-${modules.cpp.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/global-extensions-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/generic-compiler-executor-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindot-viewer-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dependency-tools-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/dumpdot-annotation-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mindc-optimizations-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/examples-${modules.common.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/mind-visual-diff-${module.diff.version}</directory>
+			<outputDirectory />
+		</fileSet>
+		<fileSet>
+			<directory>target/dependency/simple-c-macro-generator-${modules.common.version}</directory>
 			<outputDirectory />
 		</fileSet>
 	</fileSets>

--- a/src/docbkx/Mindc-and-plugins-User-guide.xml
+++ b/src/docbkx/Mindc-and-plugins-User-guide.xml
@@ -102,6 +102,35 @@
                 capabilities.</para>
             <para>The purpose of the plugins available and the way they are invoked is documented
                 hereafter.</para>
+            <section>
+                <title>Deployment style sheet</title>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
+                    href="../../global-extensions/src/docbkx/sections/Deployment-Style-Sheet_aim.xml"/>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../global-extensions/src/docbkx/sections/Deployment-Style-Sheet_usage.xml"/>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../global-extensions/src/docbkx/sections/Deployment-Style-Sheet_syntax.xml"/>
+            </section>
+            <section>
+                <title>Optimization Back-end</title>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" 
+                    href="../../Optimization-Backend/src/docbkx/sections/Optimization-backend_aim.xml"/>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../Optimization-Backend/src/docbkx/sections/Optimization-backend_usage.xml"/>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../Optimization-Backend/src/docbkx/sections/Optimization-backend_annotations.xml"/>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../Optimization-Backend/src/docbkx/sections/Optimization-backend_DSS.xml"/>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../Optimization-Backend/src/docbkx/sections/Optimization-backend_gains.xml"/>
+            </section>
+            <section>
+                <title>C macro generator plugin</title>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../simple-c-macro-generator/src/docbkx/sections/c-macro-generator_aim.xml"/>
+                <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                    href="../../simple-c-macro-generator/src/docbkx/sections/c-macro-generator_usage.xml"/>
+            </section>
         </section>
     </chapter>
     <chapter>
@@ -112,6 +141,22 @@
                 href="../../mindoc/src/docbkx/sections/mindoc_aim.xml"/>
             <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
                 href="../../mindoc/src/docbkx/sections/mindoc_cmd.xml"/>
+        </section>
+        <section>
+            <title>Mind Visual Diff tool</title>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="../../mind-visual-diff/src/docbkx/sections/mind-diff_aim.xml"/>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="../../mind-visual-diff/src/docbkx/sections/mind-diff_cmd.xml"/>
+        </section>
+        <section>
+            <title>Dependency tools</title>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="../../dependency-tools/src/docbkx/sections/dependency-tools_aim.xml"/>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="../../dependency-tools/src/docbkx/sections/object-dependencies_cmd.xml"/>
+            <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="../../dependency-tools/src/docbkx/sections/mind-violation_cmd.xml"/>
         </section>
     </chapter>
     <appendix>


### PR DESCRIPTION
# Integrate all the Mind4SE plugins
## Related Pull Request

https://github.com/MIND-Tools/mind-tools-release-manifest/pull/3
## Purpose

Building the all-in-one core MIND-Tools + Mind4SE tools package, here adding the missing:
- Optimization Backend (Smaller and faster code size, with @Static, @StaticBindings, adaptive factory code generation...)
- Global Extensions (Deployment stylesheets for annotations)
- Dumpdot Annotation (Generate dot graphics from the architecture using annotations and provided templates in runtime)
- Mindot Viewer (View the dot graphics generated with Dumpdot Annotation - Python 2.7 + PyGTK-all-in-one-2.24.0 + GraphViz 2.28 dependency)
- MindUnit (Unit tests framework, - CUnit dependency included with the example)
- IAR tools support (compiler, linker, assembler)
- DIAB tools support (compiler, linker, assembler)
- Garbage Composite Annotation (Architecture flattening - Use @Flatten)
- Mind C++ Support (Code generation backend + Small ITF grammar extensions)
- Generic compiler support helpers
- Dependency Tools (Binaries Design Structure Matrices (DSM) generation + Hack-ish binding by-passing detection)
- Latest MindEd-ready examples (Enhancing and replacing core compiler ones)
- Mind Visual Diff (Temporal and Structural Architecture Comparison, serialized in dot format, viewed with Mindot Viewer)
- Simple C Macro Generator (Simplified code generation for static analysis with Klocwork or Scanbuild - Allows compiling binaries but they will never link)
- JSON Generator (Serialize d3.js-friendly JSON from the architecture, for new cool visualizations - see http://d3js.org for more ! Such as Zoomable Treemap, Collapsible Tree, Zoomable Circle packing, Sunburst Partition...)
